### PR TITLE
Navi Ventura and Sonoma patch scripts 

### DIFF
--- a/Navi-13+/MTL6000.zsh
+++ b/Navi-13+/MTL6000.zsh
@@ -1,0 +1,97 @@
+#
+# this is based on EDUs Vega MTL patch script
+# used Hopper to indetify functions and locations
+# you will find the old Vega references in comments
+#
+# the first two patches are necessary to run on iMac12,2 RX5500XT with Ventura
+# the patching of GFX10_MtlComputePipeLineState has subtle consequences, first
+# the GPU is no longer shown in "About This Mac" since all displays are clamped
+# down and the performace on simple MetalBench get 15% up to Monterey level
+#
+# extraction with DCSE binary her called Extract
+#
+# ./Extract /System/Library/dyld/dyld_shared_cache_x86_64 /System/Library/Extensions/AMDRadeonX6000MTLDriver.bundle/Contents/MacOS
+#
+#
+./Binpatcher navi_dsce navi_reconstructed '
+# GFX10_MtlDevice computeFunctionKeyWithComputePipeLineDescriptor
+
+# set 0x132ad
+set 0x1060d2
+# assert 0x88
+write 0x80
+
+# set 0x13508
+set 0x10632d
+# assert 0x88
+write 0x80
+
+# GFX10_MtlComputePipeLineState initWithDevice
+
+# set 0x8e9ec
+set 0xb9b83
+assert 0x88
+write 0x80
+
+# set 0x8ea31
+set 0xb9bc8
+assert 0x88
+write 0x80
+
+# set 0x8ea59
+set 0xb9bf5
+assert 0x88
+write 0x80
+
+# set 0x8ea87
+set 0xb9c2b
+assert 0x88
+write 0x80
+
+# set 0x8eae2
+set 0xb9c88
+assert 0x88
+write 0x80
+
+# set 0x8eb19
+set 0xb9ce1
+assert 0x88
+write 0x80
+
+# set 0x8eb52
+set 0xb9d12
+assert 0x88
+write 0x80
+
+# set 0x8eb7b
+set 0xb9d3a
+assert 0x88
+write 0x80
+
+# set 0x8eba7
+set 0xb9d66
+assert 0x88
+write 0x80
+
+# set 0x8ec06
+set 0xb9dc3
+assert 0x88
+write 0x80
+
+# set 0x8ec06
+set 0xb9e39
+assert 0x88
+write 0x80
+
+# set 0x8ecb7
+set 0xb9e70
+assert 0x88
+write 0x80
+
+# set 0x8ee14
+set 0xb9fbf
+assert 0x88
+write 0x80
+'
+# codesign -fs - AMDRadeonX6000MTLDriver.bundle/Contents/MacOS/AMDRadeonX6000MTLDriver
+

--- a/Sonoma 14.4 IOSurface/X6000-iosurface.zsh
+++ b/Sonoma 14.4 IOSurface/X6000-iosurface.zsh
@@ -1,0 +1,63 @@
+#
+# this is based on EDUs Vega X5000 patch script
+# used Hopper to indetify functions and locations
+# you will find the old Vega references and address calculations in comments
+# checked every address and command in code manually
+#
+# tested on Sonoma 14.6.1 with iMac12,2 RX5500XT successfully
+#
+./Binpatcher AMDRadeonX6000.kext/Contents/MacOS/AMDRadeonX6000 AMDRadeonX6000.kext/Contents/MacOS/AMDRadeonX6000 '
+
+# IOSurface::getPlaneCount
+
+# AMDRadeonX6000_AMDAccelResource::zeroVidMemory
+
+# set 0x14ca1 = 0x14c9f+2
+# X6000: 0x14dcb + 2
+set 0x14dcd  
+write 0x98
+
+# AMDRadeonX6000_AMDAccelResource::getIOSurfacePlaneInfo
+
+# set 0x172c2 = 0x172c0 +2
+# X6000: 17410 + 2
+set 0x17412
+write 0x98
+
+# set 0x17313 = 0x17310 +3
+# X6000: 0x17460 + 3 
+set 0x17463
+write 0x98
+
+# AMDRadeonX6000_AMDAccelResource::fillUBMSurfaceInfoBacking
+
+# set 0x17ad2 = 0x17ace + 4
+# X6000: 0x17c84 + 4
+set 0x17c88 
+write 0x98
+
+# AMDRadeonX6000_AMDAccelResource::initIOSurface
+
+# set 0x16ac8 = 0x16ac5 + 3
+# X6000: 0x16c15 + 3
+set 0x16c18
+write 0x98
+
+# AMDRadeonX6000_AMDGFX9Resource::initIOSurface
+
+# set 0x3d112 = 0x3d10e + 4 
+# X6000: 0x3d070 + 4
+set 0x3d074
+write 0x98
+
+# IOSurface::getPixelFormat
+
+# AMDRadeonX6000_AMDAccelResource::zeroVidMemory (again)
+
+# set 0x14cae = 0x14cac + 2
+# X6000:  0x14dd8 + 2 
+set 0x14dda
+write 0x80
+'
+codesign -fs - AMDRadeonX6000.kext/Contents/MacOS/AMDRadeonX6000
+

--- a/Sonoma IOSurface/X6000-iosurface.zsh
+++ b/Sonoma IOSurface/X6000-iosurface.zsh
@@ -1,0 +1,61 @@
+#
+# this is based on EDUs Vega X5000 patch script
+# used Hopper to indetify functions and locations
+# you will find the old Vega references and address calculations in comments
+# checked every address and command in code manually
+#
+./Binpatcher AMDRadeonX6000.kext/Contents/MacOS/AMDRadeonX6000 AMDRadeonX6000.kext/Contents/MacOS/AMDRadeonX6000 '
+
+# IOSurface::getPlaneCount
+
+# AMDRadeonX6000_AMDAccelResource::zeroVidMemory
+
+# set 0x14ca1 = 0x14c9f+2
+# X6000: 0x14dcb+2
+set 0x14dcd 
+write 0xb8
+
+# AMDRadeonX6000_AMDAccelResource::getIOSurfacePlaneInfo
+
+# set 0x172c2 = 0x172c0 +2
+# X6000: 17410 +2
+set 0x17412
+write 0xb8
+
+# set 0x17313 = 0x17310 +3
+# X6000: 0x17460 +3 
+set 0x17463
+write 0xb8
+
+# AMDRadeonX6000_AMDAccelResource::fillUBMSurfaceInfoBacking
+
+# set 0x17ad2 = 0x17ace + 4
+# X6000: 0x17c84 + 4
+set 0x17c88 
+write 0xb8
+
+# AMDRadeonX6000_AMDAccelResource::initIOSurface
+
+# set 0x16ac8 = 0x16ac5 + 3 
+# X6000: 0x16c15 + 3
+set 0x16c18
+write 0xb8
+
+# AMDRadeonX6000_AMDGFX9Resource::initIOSurface
+
+# set 0x3d112 = 0x3d10e + 4 
+# X6000: 0x3d070 + 4
+set 0x3d074
+write 0xb8
+
+# IOSurface::getPixelFormat
+
+# AMDRadeonX6000_AMDAccelResource::zeroVidMemory (again)
+
+# set 0x14cae = 0x14cac + 2 
+# X6000:  0x14dd8 + 2 
+set 0x14dda
+write 0xac
+'
+codesign -fs - AMDRadeonX6000.kext/Contents/MacOS/AMDRadeonX6000
+


### PR DESCRIPTION
- tested with Ventura 13.6, Sonoma 14.6.1, and Sequoia 15.0

As usual you need to codesign all new binaries and add `amfi=0x80` to OpenCore `boot-args`.

Of course still all displays are shut down and the stock installation will not boot on any pre AVX Navi equipped Mac.
Is there a chance to block X6000 via OC on initial boot?

Usual installation and test procedure
- installed macOS using a 2nd iMac12,2 with Polaris
- set up test user and enabled remote access (ssh), screen sharing and file sharing
- patched with OCLP
- rebooted
- added Navi patches manually and ran kmutil/bless 
- booted via Thunderbolt and Target Disk Mode on the Navi iMac12,2
- connected via Screen Share and used AirPlay to 3rd iMac to get full display resolutions (limited to 1960x1028 on boot)

BTW: The X6000 framebuffer code from 12.5 and 13.6 is bit by bit identical. 

![Sequoia-NAVI](https://github.com/user-attachments/assets/8d3a7a84-8c3e-4950-8541-1747febd84a8)
![Sonoma-NAVI](https://github.com/user-attachments/assets/a95281a5-6acf-406d-aa5e-1b98d06ffa16)
